### PR TITLE
Add missing OSSRH repository to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,10 @@
             <id>CodeMC</id>
             <url>https://repo.codemc.org/repository/maven-public</url>
         </repository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </repository>
     </repositories>
 
     <dependencies>


### PR DESCRIPTION
The OSSRH repository has snapshots for me.machinemaker.config-manager, but it was missing from pom.xml