### PR TITLE
Player graves - ArmorStand protection, using drops and storing off hand item in grave.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,10 @@
             <id>CodeMC</id>
             <url>https://repo.codemc.org/repository/maven-public</url>
         </repository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </repository>
     </repositories>
 
     <dependencies>

--- a/src/main/java/me/machinemaker/vanillatweaks/playergraves/PlayerGraves.java
+++ b/src/main/java/me/machinemaker/vanillatweaks/playergraves/PlayerGraves.java
@@ -4,7 +4,9 @@ import com.google.common.collect.Lists;
 import me.machinemaker.vanillatweaks.BaseModule;
 import me.machinemaker.vanillatweaks.Lang;
 import me.machinemaker.vanillatweaks.VanillaTweaks;
+import me.machinemaker.vanillatweaks.utils.CachedHashObjectWrapper;
 import me.machinemaker.vanillatweaks.utils.DataType;
+import org.apache.commons.lang.mutable.MutableInt;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -20,12 +22,15 @@ import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerArmorStandManipulateEvent;
 import org.bukkit.event.player.PlayerToggleSneakEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
+import org.jetbrains.annotations.NotNull;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
+
+import static me.machinemaker.vanillatweaks.utils.VTUtils.nullUnionList;
+import static me.machinemaker.vanillatweaks.utils.VTUtils.toCachedMapCount;
 
 public class PlayerGraves extends BaseModule implements Listener {
 
@@ -44,19 +49,21 @@ public class PlayerGraves extends BaseModule implements Listener {
     @EventHandler
     public void onPlayerDeath(PlayerDeathEvent event) {
         if (event.getKeepInventory()) return;
-        boolean empty = true;
-        for (ItemStack stack : event.getEntity().getInventory().getContents()) {
-            if (stack != null) {
-                empty = false;
-                break;
-            }
-        }
-        if (empty) return;
+        if (event.getDrops().isEmpty()) return;
         Block spawnBlock = event.getEntity().getLocation().getBlock();
         while (spawnBlock.getType() == Material.AIR) {
             spawnBlock = spawnBlock.getRelative(BlockFace.DOWN);
         }
         Location location = spawnBlock.getRelative(BlockFace.UP).getLocation().add(0.5, 0, 0.5);
+        PlayerInventory inventory = event.getEntity().getInventory();
+        List<ItemStack> drops = event.getDrops();
+        @NotNull Map<CachedHashObjectWrapper<ItemStack>, MutableInt> cachedDrops = toCachedMapCount(drops);
+        List<ItemStack> armorContents = Arrays.asList(inventory.getArmorContents());
+        List<ItemStack> inventoryContents = Arrays.asList(inventory.getStorageContents());
+        armorContents = nullUnionList(armorContents, cachedDrops);
+        inventoryContents = nullUnionList(inventoryContents, cachedDrops);
+        drops.clear(); // We could assert that cachedDrops is empty
+
         event.getEntity().sendMessage(Lang.GRAVE_AT.p().replace("%x%", String.valueOf(location.getBlockX())).replace("%y%", String.valueOf(location.getBlockY())).replace("%z%", String.valueOf(location.getBlockZ())));
         Long timestamp = System.currentTimeMillis();
         ArmorStand block = (ArmorStand) location.getWorld().spawnEntity(location.clone().subtract(-0.1, 1.77, 0), EntityType.ARMOR_STAND);
@@ -66,13 +73,11 @@ public class PlayerGraves extends BaseModule implements Listener {
         ArmorStand headstone = (ArmorStand) location.getWorld().spawnEntity(location.clone().subtract(0.3, 1.37, 0), EntityType.ARMOR_STAND);
         PersistentDataContainer container = headstone.getPersistentDataContainer();
         container.set(PLAYER_UUID, DataType.UUID, event.getEntity().getUniqueId());
-        container.set(PLAYER_INV_CONTENTS, DataType.ITEMSTACK_ARRAY, event.getEntity().getInventory().getStorageContents());
-        container.set(PLAYER_ARM_CONTENTS, DataType.ITEMSTACK_ARRAY, event.getEntity().getInventory().getArmorContents());
+        container.set(PLAYER_INV_CONTENTS, DataType.ITEMSTACK_ARRAY, inventoryContents.toArray(new ItemStack[0]));
+        container.set(PLAYER_ARM_CONTENTS, DataType.ITEMSTACK_ARRAY, armorContents.toArray(new ItemStack[0]));
         container.set(TIMESTAMP, PersistentDataType.LONG, timestamp);
         setupStand(headstone, graves.get(0));
         Collections.shuffle(graves);
-        event.getDrops().clear();
-        event.getEntity().getInventory().clear();
     }
 
     @EventHandler

--- a/src/main/java/me/machinemaker/vanillatweaks/playergraves/PlayerGraves.java
+++ b/src/main/java/me/machinemaker/vanillatweaks/playergraves/PlayerGraves.java
@@ -14,8 +14,10 @@ import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerArmorStandManipulateEvent;
 import org.bukkit.event.player.PlayerToggleSneakEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataContainer;
@@ -27,6 +29,7 @@ import java.util.List;
 
 public class PlayerGraves extends BaseModule implements Listener {
 
+    private final NamespacedKey PROTECTED = new NamespacedKey(this.plugin, "protected");
     private final NamespacedKey TIMESTAMP = new NamespacedKey(this.plugin, "timestamp");
     private final NamespacedKey PLAYER_UUID = new NamespacedKey(this.plugin, "player_uuid");
     private final NamespacedKey PLAYER_INV_CONTENTS = new NamespacedKey(this.plugin, "player_inventory_contents");
@@ -96,12 +99,20 @@ public class PlayerGraves extends BaseModule implements Listener {
         });
     }
 
+    // Don't let players mess with the graves
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onArmorStandManipulation(PlayerArmorStandManipulateEvent event) {
+        PersistentDataContainer pdc = event.getRightClicked().getPersistentDataContainer();
+        if (pdc.get(PROTECTED, PersistentDataType.BYTE) != null) event.setCancelled(true);
+    }
+
     private void setupStand(ArmorStand stand, Material head) {
         stand.setInvulnerable(true);
         stand.setGravity(false);
         stand.setVisible(false);
         stand.setArms(false);
         stand.setCollidable(false);
+        stand.getPersistentDataContainer().set(PROTECTED, PersistentDataType.BYTE, (byte)1);
         stand.getEquipment().setHelmet(new ItemStack(head));
     }
 

--- a/src/main/java/me/machinemaker/vanillatweaks/playergraves/PlayerGraves.java
+++ b/src/main/java/me/machinemaker/vanillatweaks/playergraves/PlayerGraves.java
@@ -39,6 +39,7 @@ public class PlayerGraves extends BaseModule implements Listener {
     private final NamespacedKey PLAYER_UUID = new NamespacedKey(this.plugin, "player_uuid");
     private final NamespacedKey PLAYER_INV_CONTENTS = new NamespacedKey(this.plugin, "player_inventory_contents");
     private final NamespacedKey PLAYER_ARM_CONTENTS = new NamespacedKey(this.plugin, "player_armor_contents");
+    private final NamespacedKey PLAYER_EXTRA_CONTENTS = new NamespacedKey(this.plugin, "player_extra_contents");
 
     private final List<Material> graves = Lists.newArrayList(Material.COBBLESTONE_WALL, Material.MOSSY_COBBLESTONE_WALL);
 
@@ -62,6 +63,8 @@ public class PlayerGraves extends BaseModule implements Listener {
         List<ItemStack> inventoryContents = Arrays.asList(inventory.getStorageContents());
         armorContents = nullUnionList(armorContents, cachedDrops);
         inventoryContents = nullUnionList(inventoryContents, cachedDrops);
+        List<ItemStack> extraContents = Arrays.asList(inventory.getExtraContents());
+        extraContents = nullUnionList(extraContents, cachedDrops);
         drops.clear(); // We could assert that cachedDrops is empty
 
         event.getEntity().sendMessage(Lang.GRAVE_AT.p().replace("%x%", String.valueOf(location.getBlockX())).replace("%y%", String.valueOf(location.getBlockY())).replace("%z%", String.valueOf(location.getBlockZ())));
@@ -75,6 +78,7 @@ public class PlayerGraves extends BaseModule implements Listener {
         container.set(PLAYER_UUID, DataType.UUID, event.getEntity().getUniqueId());
         container.set(PLAYER_INV_CONTENTS, DataType.ITEMSTACK_ARRAY, inventoryContents.toArray(new ItemStack[0]));
         container.set(PLAYER_ARM_CONTENTS, DataType.ITEMSTACK_ARRAY, armorContents.toArray(new ItemStack[0]));
+        container.set(PLAYER_EXTRA_CONTENTS, DataType.ITEMSTACK_ARRAY, extraContents.toArray(new ItemStack[0]));
         container.set(TIMESTAMP, PersistentDataType.LONG, timestamp);
         setupStand(headstone, graves.get(0));
         Collections.shuffle(graves);
@@ -95,10 +99,13 @@ public class PlayerGraves extends BaseModule implements Listener {
             for (ItemStack stack : event.getPlayer().getInventory().getContents()) {
                 if (stack != null) event.getPlayer().getLocation().getWorld().dropItemNaturally(event.getPlayer().getLocation(), stack);
             }
+            PlayerInventory inventory = event.getPlayer().getInventory();
             ItemStack[] storage = container.get(PLAYER_INV_CONTENTS, DataType.ITEMSTACK_ARRAY);
             ItemStack[] armor = container.get(PLAYER_ARM_CONTENTS, DataType.ITEMSTACK_ARRAY);
-            event.getPlayer().getInventory().setStorageContents(storage);
-            event.getPlayer().getInventory().setArmorContents(armor);
+            ItemStack[] extra = container.get(PLAYER_EXTRA_CONTENTS, DataType.ITEMSTACK_ARRAY);
+            inventory.setStorageContents(storage);
+            inventory.setArmorContents(armor);
+            inventory.setExtraContents(extra);
             event.getPlayer().sendMessage("Retrieved items");
             entity.remove();
         });

--- a/src/main/java/me/machinemaker/vanillatweaks/utils/CachedHashObjectWrapper.java
+++ b/src/main/java/me/machinemaker/vanillatweaks/utils/CachedHashObjectWrapper.java
@@ -1,0 +1,26 @@
+package me.machinemaker.vanillatweaks.utils;
+
+import java.util.Objects;
+
+/**
+ * Caches the hash code of the wrapped object
+ * @param <T>
+ */
+public class CachedHashObjectWrapper<T> {
+    public final T item;
+    private final int hash;
+    public CachedHashObjectWrapper(T item) {
+        this.item = item;
+        this.hash = Objects.hash(item);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return item.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return hash;
+    }
+}

--- a/src/main/java/me/machinemaker/vanillatweaks/utils/VTUtils.java
+++ b/src/main/java/me/machinemaker/vanillatweaks/utils/VTUtils.java
@@ -2,12 +2,13 @@ package me.machinemaker.vanillatweaks.utils;
 
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
+import org.apache.commons.lang.mutable.MutableInt;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
+import org.jetbrains.annotations.NotNull;
 
-import java.util.Collection;
-import java.util.UUID;
+import java.util.*;
 
 public class VTUtils {
 
@@ -26,5 +27,36 @@ public class VTUtils {
         int num = (int) (Math.random() * coll.size());
         for(T t: coll) if (--num < 0) return t;
         throw new AssertionError();
+    }
+
+    public static <T> @NotNull Map<CachedHashObjectWrapper<T>, MutableInt> toCachedMapCount(@NotNull List<T> list) {
+        Map<CachedHashObjectWrapper<T>, MutableInt> listCount = new HashMap<>();
+        for (T item : list) {
+            listCount.computeIfAbsent(new CachedHashObjectWrapper<>(item), (k) -> new MutableInt()).increment();
+        }
+        return listCount;
+    }
+
+    /**
+     * Replaces all occurrences of items from {unioned} that are not in {with} with null.
+     */
+    public static <T> @NotNull List<T> nullUnionList(@NotNull List<T> unioned, @NotNull List<T> with) {
+        @NotNull Map<CachedHashObjectWrapper<T>, MutableInt> withCount = toCachedMapCount(with);
+        return nullUnionList(unioned, withCount);
+    }
+
+    public static <T> @NotNull List<T> nullUnionList(@NotNull List<T> unioned,
+                                                     @NotNull Map<CachedHashObjectWrapper<T>, MutableInt> with) {
+        List<T> result = new ArrayList<>();
+        for (T item: unioned) {
+            MutableInt x = with.get(new CachedHashObjectWrapper<>(item));
+            if (x == null || x.intValue() <= 0) {
+                result.add(item);
+            } else {
+                result.add(null);
+                x.decrement();
+            }
+        }
+        return result;
     }
 }


### PR DESCRIPTION
This PR is split into 3 commits, which should be independent, unless I made a mistake when committing changes.

1. It adds protection to the armor stands - previously you could pick up the blocks off of armor stands.
2. It supports other plugins removing things from `getDrops()` list only. This is expected behavior of such plugins, so previous implementation could potentially lead to a dupe.
An easy example would be having CurseOfVanishing implemented by listening to this event and removing all drops that have that enchantment.
I'm not 100% proud of the way it's done - but I've went through 3 smaller, previous solutions with good people over at #paper-dev, and this is best we could come up with.
3. Stores all other slots - this includes offhand.

If a person has item in crafting grid on death, it still drops that item - could be fixed at some point :)