### PR TITLE
feat: cauldron mud functionality

### DIFF
--- a/src/main/java/me/machinemaker/papertweaks/modules/survival/cauldronmud/CauldronListener.java
+++ b/src/main/java/me/machinemaker/papertweaks/modules/survival/cauldronmud/CauldronListener.java
@@ -1,0 +1,32 @@
+package me.machinemaker.papertweaks.modules.survival.cauldronmud;
+
+import io.papermc.paper.event.entity.EntityInsideBlockEvent;
+import java.util.Set;
+import me.machinemaker.papertweaks.modules.ModuleListener;
+import org.bukkit.Material;
+import org.bukkit.entity.Item;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.inventory.ItemStack;
+
+class CauldronListener implements ModuleListener {
+
+    private static final Set<Material> VALID_DIRT_TYPES = Set.of(
+        Material.DIRT,
+        Material.COARSE_DIRT,
+        Material.ROOTED_DIRT
+    );
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onEntityInsideBlock(final EntityInsideBlockEvent event) {
+        if (event.getEntity() instanceof final Item item
+            && event.getBlock().getType() == Material.WATER_CAULDRON
+            && VALID_DIRT_TYPES.contains(item.getItemStack().getType())) {
+            item.getWorld().dropItem(
+                item.getLocation(),
+                new ItemStack(CauldronMud.toMudFromDirt(item.getItemStack().getType()), item.getItemStack().getAmount())
+            );
+            item.remove();
+        }
+    }
+}

--- a/src/main/java/me/machinemaker/papertweaks/modules/survival/cauldronmud/CauldronMud.java
+++ b/src/main/java/me/machinemaker/papertweaks/modules/survival/cauldronmud/CauldronMud.java
@@ -1,0 +1,50 @@
+/*
+ * GNU General Public License v3
+ *
+ * PaperTweaks, a performant replacement for the VanillaTweaks datapacks.
+ *
+ * Copyright (C) 2021-2025 Machine_Maker
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package me.machinemaker.papertweaks.modules.survival.cauldronmud;
+
+import java.util.Collection;
+import java.util.Set;
+import me.machinemaker.papertweaks.annotations.ModuleInfo;
+import me.machinemaker.papertweaks.modules.ModuleBase;
+import me.machinemaker.papertweaks.modules.ModuleLifecycle;
+import me.machinemaker.papertweaks.modules.ModuleListener;
+import org.bukkit.Material;
+
+@ModuleInfo(name = "CauldronMud", configPath = "survival.cauldron-mud", description = "Make mud using cauldrons")
+public class CauldronMud extends ModuleBase {
+
+    static Material toMudFromDirt(final Material dirt) {
+        if (!(dirt.equals(Material.DIRT) || dirt.equals(Material.COARSE_DIRT) || dirt.equals(Material.ROOTED_DIRT))) {
+            throw new IllegalArgumentException(dirt + " is not a valid dirt type!");
+        }
+
+        return Material.MUD;
+    }
+
+    @Override
+    protected Collection<Class<? extends ModuleListener>> listeners() {
+        return Set.of(CauldronListener.class);
+    }
+
+    @Override
+    protected Class<? extends ModuleLifecycle> lifecycle() {
+        return ModuleLifecycle.Empty.class;
+    }
+}

--- a/src/main/java/me/machinemaker/papertweaks/modules/survival/cauldronmud/package-info.java
+++ b/src/main/java/me/machinemaker/papertweaks/modules/survival/cauldronmud/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * GNU General Public License v3
+ *
+ * PaperTweaks, a performant replacement for the VanillaTweaks datapacks.
+ *
+ * Copyright (C) 2021-2025 Machine_Maker
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+/**
+ * Cauldron Mud module
+ */
+@DefaultQualifier(NonNull.class)
+package me.machinemaker.papertweaks.modules.survival.cauldronmud;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;


### PR DESCRIPTION
https://vanillatweaks.net/picker/datapacks/

Adds cauldron mud datapack in similar fashion as Cauldron Concrete from vanilla tweaks site.

![image](https://github.com/user-attachments/assets/667f3f57-8775-42c6-bb36-c2de95944cfb)

Takes in [dirt](https://minecraft.wiki/w/Dirt), [coarse dirt](https://minecraft.wiki/w/Coarse_dirt), [rooted dirt](https://minecraft.wiki/w/Rooted_dirt) and transforms it into mud in a cauldron. 