### PR TITLE
feat(ConfettiCreepers): charged creeper config

### DIFF
--- a/src/main/java/me/machinemaker/papertweaks/modules/experimental/confetticreepers/Config.java
+++ b/src/main/java/me/machinemaker/papertweaks/modules/experimental/confetticreepers/Config.java
@@ -20,6 +20,7 @@
 package me.machinemaker.papertweaks.modules.experimental.confetticreepers;
 
 import me.machinemaker.lectern.annotations.Description;
+import me.machinemaker.lectern.annotations.Key;
 import me.machinemaker.papertweaks.config.PTConfig;
 import me.machinemaker.papertweaks.modules.ModuleConfig;
 
@@ -28,4 +29,8 @@ class Config extends ModuleConfig {
 
     @Description("Value between 0 (inclusive) and 1.0 (inclusive) for the chance a creeper will be a confetti creeper")
     public double chance = 1D;
+
+    @Key("allow-charged-creepers")
+    @Description("Allows charged creepers to explode normally, restoring the ability to obtain mob heads")
+    public boolean allowChargedCreepers = false;
 }

--- a/src/main/java/me/machinemaker/papertweaks/modules/experimental/confetticreepers/ExplosionListener.java
+++ b/src/main/java/me/machinemaker/papertweaks/modules/experimental/confetticreepers/ExplosionListener.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import me.machinemaker.papertweaks.modules.ModuleListener;
 import org.bukkit.Color;
 import org.bukkit.FireworkEffect;
+import org.bukkit.entity.Creeper;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Firework;
 import org.bukkit.event.EventHandler;
@@ -57,6 +58,10 @@ public class ExplosionListener implements ModuleListener {
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onExplosionPrime(final ExplosionPrimeEvent event) {
         if (event.getEntityType() != EntityType.CREEPER) return;
+        if (this.config.allowChargedCreepers) {
+            Creeper creeper = (Creeper) event.getEntity();
+            if (creeper.isPowered()) return;
+        }
         if (ThreadLocalRandom.current().nextDouble() < this.config.chance) {
             event.setFire(false);
             event.setRadius(0);


### PR DESCRIPTION
Adds a config option to ConfettiCreepers that allows charged creepers to explode normally, restoring the ability to obtain mob heads in survival